### PR TITLE
refactor: rename createRoutes to createRoute for consistency

### DIFF
--- a/src/helpers/create-routes.ts
+++ b/src/helpers/create-routes.ts
@@ -1,5 +1,5 @@
 import Route from '../types/routes';
 
-export default function createRoute<T>(routes: Route<T>): Route<any> {
-  return routes;
+export default function createRoute<T>(route: Route<T>): Route<any> {
+  return route;
 }

--- a/src/helpers/create-routes.ts
+++ b/src/helpers/create-routes.ts
@@ -1,5 +1,5 @@
 import Route from '../types/routes';
 
-export default function createRoutes<T>(routes: Route<T>): Route<T> {
+export default function createRoute<T>(routes: Route<T>): Route<any> {
   return routes;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,9 @@
-import { da, faker } from '@faker-js/faker';
+import { faker } from '@faker-js/faker';
 import buildApp from './app';
-import createRoutes from './helpers/create-routes';
-import Route from './types/routes';
+import createRoute from './helpers/create-routes';
 
 // Global mock routes with Faker function mappings
-const productsRoute = createRoutes({
+const productsRoute = createRoute({
   path: '/products',
   method: 'get',
   response: {
@@ -56,7 +55,7 @@ const productsRoute = createRoutes({
   ],
 });
 
-const productByIdRoute: Route<any> = createRoutes({
+const productByIdRoute = createRoute({
   path: '/products/:id',
   method: 'get',
   response: {


### PR DESCRIPTION
Update the route creation function to a singular naming convention, enhancing clarity in the codebase. Adjust references in main.ts to reflect this change.